### PR TITLE
WIP: stab at cluster-down

### DIFF
--- a/playbooks/cluster-down.yaml
+++ b/playbooks/cluster-down.yaml
@@ -1,8 +1,13 @@
-# WIP
-- hosts: "tag_Name_{{ tag_name }}"
-  gatherfacts: True
-  
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
   tasks:
-  - name: debug
-    ping:
-      
+    - ec2_instance_facts:
+        filters:
+          "tag:Name": ansible-cluster-deploy-demo
+
+    - name: terminate matching ec2 instances
+      ec2:
+        state: absent
+        instance_ids: "{{ hostvars[host]['ec2_id'] }}"


### PR DESCRIPTION
cluster-down currently fails with 
```
: ansible-playbook -i inventories/ playbooks/cluster-down.yaml 

PLAY [localhost] **************************************************************************************

TASK [ec2_instance_facts] *****************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "boto3 required for this module"}
	to retry, use: --limit @/root/yard-turkey/ansible-cloud-deploy/playbooks/cluster-down.retry

PLAY RECAP ********************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```

but maybe it's a start...