### PR TITLE
simple start/stop playbooks

### DIFF
--- a/playbooks/cluster-down.yaml
+++ b/playbooks/cluster-down.yaml
@@ -6,6 +6,8 @@
   gather_facts: false
 
   tasks:
+  - import_tasks: tasks/check-ssh.yaml
+
   - ec2_instance_facts:
       filters:
         "tag:Name": "{{ tag_name }}"
@@ -18,7 +20,6 @@
       region: "{{ region }}"
       group: ec2hosts
     loop: "{{ ec2_facts.instances }}"
-
 
 - hosts: ec2hosts
   name: Shutdown hosts

--- a/playbooks/cluster-up.yaml
+++ b/playbooks/cluster-up.yaml
@@ -6,8 +6,7 @@
   gather_facts: False
 
   tasks:
-  - name: "Checking ssh-agent is running and '{{ ssh_key }}' key is loaded"
-    shell: "ssh-add -l | grep {{ ssh_key | quote }}"
+  - import_tasks: tasks/check-ssh.yaml
 
   - name: spin up instances
     ec2:

--- a/playbooks/start.yaml
+++ b/playbooks/start.yaml
@@ -1,0 +1,20 @@
+# Start all instances matching the passed-in name tag.
+# No dep on ec2.py
+# Required vars ('-e var=val'):
+#   tag_name=<instances-name>, eg. -e tag_name="jvance-demo"
+
+- hosts: localhost 
+  gather_facts: False
+
+  tasks:
+  - import_tasks: tasks/check-ssh.yaml
+
+  - name: "start instances matching '{{ tag_name }}'"
+    ec2_instance:
+      key_name: "{{ ssh_key }}"
+      ec2_region: "{{ region  }}" 
+      #vpc_subnet_id: "{{ subnet_id }}"
+      state: running
+      filters:
+        "tag:Name": "{{ tag_name }}"
+      wait: true

--- a/playbooks/stop.yaml
+++ b/playbooks/stop.yaml
@@ -1,0 +1,20 @@
+# Stop all running instances matching the passed-in name tag.
+# No dep on ec2.py
+# Required vars ('-e var=val'):
+#   tag_name=<instances-name>, eg. -e tag_name="jvance-demo"
+
+- hosts: localhost 
+  gather_facts: False
+
+  tasks:
+  - import_tasks: tasks/check-ssh.yaml
+
+  - name: "stop instances matching '{{ tag_name }}'"
+    ec2_instance:
+      key_name: "{{ ssh_key }}"
+      ec2_region: "{{ region  }}" 
+      state: stopped 
+      filters:
+        "tag:Name": "{{ tag_name }}"
+        instance-state-name: "running"
+      wait: true

--- a/playbooks/tasks/check-ssh.yaml
+++ b/playbooks/tasks/check-ssh.yaml
@@ -1,0 +1,2 @@
+- name: "Checking ssh-agent is running and '{{ ssh_key }}' key is loaded"
+  shell: "ssh-add -l | grep {{ ssh_key | quote }}"


### PR DESCRIPTION
start and stop are idempotent.
I had bigger plans that included collecting inventory facts in order to display messages such as the number of instances targeted to be stopped or started, etc., but ran into a few glitches, and, not wanting to use ec2.py, these simple playbooks will suffice for now.