### PR TITLE
Use instance id to identify hosts, no public dns exists

### DIFF
--- a/playbooks/cluster-down.yaml
+++ b/playbooks/cluster-down.yaml
@@ -13,8 +13,7 @@
     register: ec2_facts
 
   - add_host:
-      hostname: "{{ item.public_dns_name }}"
-      id: "{{ item.instance_id }}"
+      hostname: "{{ item.instance_id }}"
       region: "{{ region }}"
       group: ec2hosts
     loop: "{{ ec2_facts.instances }}"
@@ -28,14 +27,14 @@
   - name: stopping instances 
     ec2:
       region: "{{ hostvars[inventory_hostname].region }}"
-      instance_id: "{{ hostvars[inventory_hostname].id }}"
+      instance_id: "{{ inventory_hostname  }}"
       state: stopped
       wait: true
     delegate_to: localhost
 
   - name: marking instances for deletion
     ec2_tag:
-      resource: "{{ hostvars[inventory_hostname].id }}"
+      resource: "{{ inventory_hostname }}"
       region: "{{ hostvars[inventory_hostname].region }}"
       state: present 
       tags:


### PR DESCRIPTION
When instances are stopped, they have no public IP or DNS name.  This causes the `cluster-down` playbook to error when assembling a list of hosts by hostname. Instead, use the instance_id as the hostname to guarantee idempotency. 